### PR TITLE
Merge upstream changes

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -21,11 +21,6 @@ import (
 	"github.com/mozilla-services/heka/pipeline"
 )
 
-const (
-	raven_client_id    = "raven-go/1.0"
-	raven_protocol_rev = 2.0
-)
-
 type SentryMsg struct {
 	encodedPayload string
 	dsn            string

--- a/sentry.go
+++ b/sentry.go
@@ -70,9 +70,7 @@ func (so *SentryOutput) prepSentryMsg(pack *pipeline.PipelinePack,
 }
 
 func (so *SentryOutput) getClient(dsn string) (client *raven.Client, err error) {
-	var (
-		ok bool
-	)
+	var ok bool
 	if client, ok = so.clientMap[dsn]; !ok {
 		client, err = raven.NewClient(dsn, nil)
 	}


### PR DESCRIPTION
Merge all upstream changes from: https://github.com/mozilla-services/heka-mozsvc-plugins/commits/dev

except 36fe7da278a8b626134c9f3e77743a835b50aa2a (https://github.com/mozilla-services/heka-mozsvc-plugins/pull/26) which would require using go-mock fork throughout clever private.

I think in a separate PR we can make sure to build the latest Heka and get all our changes into it, but this is the minimal change to get Heka private's build passing.
