### PR TITLE
require encoder for SentryOutput

### DIFF
--- a/sentry_test.go
+++ b/sentry_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
+	"github.com/mozilla-services/heka/plugins"
 	plugins_ts "github.com/mozilla-services/heka/plugins/testsupport"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
@@ -42,9 +43,21 @@ func getSentryPack() (pack *pipeline.PipelinePack) {
 	return
 }
 
+func getSentryPackWithoutDsn() (pack *pipeline.PipelinePack) {
+	recycleChan := make(chan *pipeline.PipelinePack, 1)
+	pack = pipeline.NewPipelinePack(recycleChan)
+	pack.Message.SetType("sentry")
+	pack.Message.SetPayload(PAYLOAD)
+	pack.Decoded = true
+	pack.Message.SetTimestamp(int64(EPOCH_TS * 1e9))
+	return
+}
+
 func SentryOutputSpec(c gs.Context) {
 
 	t := new(pipeline_ts.SimpleT)
+	encoder := new(plugins.PayloadEncoder)
+	encoder.Init(new(plugins.PayloadEncoderConfig))
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -76,7 +89,7 @@ func SentryOutputSpec(c gs.Context) {
 			oth := plugins_ts.NewOutputTestHelper(ctrl)
 			inChan := make(chan *pipeline.PipelinePack, 1)
 			oth.MockOutputRunner.EXPECT().InChan().Return(inChan)
-
+			oth.MockOutputRunner.EXPECT().Encoder().Return(encoder)
 			pack := getSentryPack()
 			inChan <- pack
 			close(inChan)
@@ -85,4 +98,21 @@ func SentryOutputSpec(c gs.Context) {
 		})
 	})
 
+	c.Specify("A SentryOutput with dsn config", func() {
+		output := new(SentryOutput)
+		conf := output.ConfigStruct().(*SentryOutputConfig)
+		conf.Dsn = DSN
+		output.Init(conf)
+		c.Specify("calls CaptureMessage with the payload when it has a dsn", func() {
+			oth := plugins_ts.NewOutputTestHelper(ctrl)
+			inChan := make(chan *pipeline.PipelinePack, 1)
+			oth.MockOutputRunner.EXPECT().InChan().Return(inChan)
+			oth.MockOutputRunner.EXPECT().Encoder().Return(encoder)
+			pack := getSentryPackWithoutDsn()
+			inChan <- pack
+			close(inChan)
+
+			output.Run(oth.MockOutputRunner, oth.MockHelper)
+		})
+	})
 }


### PR DESCRIPTION
As a best practice, I'm converting outputs to use encoders. Setting `PayloadEncoder` keeps the previous behavior for all Outputs I've modified this way, so far.

This lets us also use a FieldEncoder to remap fields via configuration in Heka toml: https://github.com/Clever/heka-clever-plugins/pull/9

Most immediately I want to use this to write the SentryDSN via FieldEncoder when the message gets to the `SentryOutput`, instead of needing to have the SentryDSN written during the decoding step, which we're doing now.
